### PR TITLE
[FEAT] add 500 error response to routers

### DIFF
--- a/src/routes/questions.js
+++ b/src/routes/questions.js
@@ -6,18 +6,22 @@ const pool = require('../models/DbConnection');
 const QUESTION_COUNT = 12;
 
 router.get('', async (req, res) => {
-  const [questions] = await pool.query('SELECT qid, content FROM questions');
-  const result = questions.map(async (q) => {
-    const [choices] = await pool.query(
-      `SELECT content, ${new Array(QUESTION_COUNT)
-        .fill('type')
-        .map((type, i) => `${type}${i + 1}`)
-        .join(', ')} FROM choices WHERE qid=${q.qid}`,
-    );
-    return { ...q, choices };
-  });
-  const resolved = await Promise.all(result);
-  res.status(200).json({ resolved });
+  try {
+    const [questions] = await pool.query('SELECT qid, content FROM questions');
+    const result = questions.map(async (q) => {
+      const [choices] = await pool.query(
+        `SELECT content, ${new Array(QUESTION_COUNT)
+          .fill('type')
+          .map((type, i) => `${type}${i + 1}`)
+          .join(', ')} FROM choices WHERE qid=${q.qid}`,
+      );
+      return { ...q, choices };
+    });
+    const resolved = await Promise.all(result);
+    res.status(200).json({ resolved });
+  } catch (err) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
 });
 
 module.exports = router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -4,8 +4,12 @@ const router = express.Router();
 const pool = require('../models/DbConnection');
 
 router.get('', async (req, res) => {
-  const result = await pool.query('SELECT COUNT(*) AS count FROM results');
-  res.json({ result: result[0][0].count });
+  try {
+    const result = await pool.query('SELECT COUNT(*) AS count FROM results');
+    res.status(200).json({ result: result[0][0].count });
+  } catch (err) {
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
[요약]
덜 세련된 방식일 수 있지만, 각 라우터에서 예외 상황을 캐치하고 그 때 500 에러 반환과 동시에 에러 메시지를 json으로 반환하게끔 하는 방식으로 에러 핸들링 추가했습니다. 

[특이사항]
- 아직 results router는 수정하지 않았습니다. 해당 router 수정 PR이 merge 된 뒤에, rebase 작업하여 수정 사항 추가하고 다시 커밋할 예정입니다. 